### PR TITLE
Add is_name predicate

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -574,6 +574,10 @@ class BaseSegment:
         """Is this segment (or its parent) of the given type."""
         return self.class_is_type(*seg_type)
 
+    def is_name(self, *seg_name):
+        """Is this segment of the given name."""
+        return any(s == self.name for s in seg_name)
+
     def invalidate_caches(self):
         """Invalidate the cached properties.
 

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -574,6 +574,10 @@ class BaseSegment:
         """Is this segment (or its parent) of the given type."""
         return self.class_is_type(*seg_type)
 
+    def get_name(self):
+        """Returns the name of this segment as a string."""
+        return self.name
+
     def is_name(self, *seg_name):
         """Is this segment of the given name."""
         return any(s == self.name for s in seg_name)

--- a/src/sqlfluff/core/rules/functional/segment_predicates.py
+++ b/src/sqlfluff/core/rules/functional/segment_predicates.py
@@ -62,6 +62,11 @@ def get_type(segment: BaseSegment) -> str:
     return segment.get_type()
 
 
+def get_name(segment: BaseSegment) -> str:
+    """Returns segment name."""
+    return segment.get_name()
+
+
 def and_(
     fn1: Callable[[BaseSegment], bool], fn2: Callable[[BaseSegment], bool]
 ) -> Callable[[BaseSegment], bool]:  # pragma: no cover

--- a/src/sqlfluff/core/rules/functional/segment_predicates.py
+++ b/src/sqlfluff/core/rules/functional/segment_predicates.py
@@ -18,6 +18,15 @@ def is_type(*seg_type: str) -> Callable[[BaseSegment], bool]:  # pragma: no cove
     return _
 
 
+def is_name(*seg_name: str) -> Callable[[BaseSegment], bool]:  # pragma: no cover
+    """Returns a function that determines if segment is one the names."""
+
+    def _(segment: BaseSegment):
+        return segment.is_name(*seg_name)
+
+    return _
+
+
 def is_code(segment: BaseSegment) -> bool:
     """Check if segment is code."""
     return segment.is_code

--- a/src/sqlfluff/rules/L013.py
+++ b/src/sqlfluff/rules/L013.py
@@ -49,7 +49,7 @@ class Rule_L013(BaseRule):
             sp.is_type("alias_expression")
         ):
             types = set(
-                children.select([lambda s: s.name != "star"]).apply(sp.get_type)
+                children.select([sp.not_(sp.is_name("star"))]).apply(sp.get_type)
             )
             unallowed_types = types - {
                 "whitespace",

--- a/src/sqlfluff/rules/L021.py
+++ b/src/sqlfluff/rules/L021.py
@@ -41,7 +41,7 @@ class Rule_L021(BaseRule):
                 segment.children(sp.is_type("select_clause"))
                 .children(sp.is_type("select_clause_modifier"))
                 .children(sp.is_type("keyword"))
-                .select([lambda s: s.name == "distinct"])
+                .select([sp.is_name("distinct")])
             )
             if distinct:
                 return LintResult(anchor=distinct[0])


### PR DESCRIPTION
Adds `.is_name` method to base segment (it's inherited by raw also). Returns true if one of the supplied names matches the segment name (like `.is_type`).

Adds the `is_name` predicate. Allows for name conditions to be combined with other predicates.

Updates L013 and L021 to use this.

Adds `get_name` predicate (similar to `get_type`)