### PR TITLE
Fix L009 predicate implementation

### DIFF
--- a/plugins/sqlfluff-templater-dbt/test/rules_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/rules_test.py
@@ -18,7 +18,7 @@ from test.fixtures.dbt.templater import (  # noqa
         # Group By
         ("L021", "models/my_new_project/select_distinct_group_by.sql", [(1, 8)]),
         # Multiple trailing newline
-        ("L009", "models/my_new_project/multiple_trailing_newline.sql", [(2, 13)]),
+        ("L009", "models/my_new_project/multiple_trailing_newline.sql", [(3, 1)]),
     ],
 )
 def test__rules__std_file_dbt(rule, path, violations, project_dir):  # noqa

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -95,7 +95,7 @@ class Rule_L009(BaseRule):
         # Find the trailing newline segments.
         trailing_newlines = reversed_complete_stack.select(
             select_if=[sp.is_type("newline")],
-            loop_while=[sp.or_(sp.is_whitespace, sp.is_meta)],
+            loop_while=[sp.or_(sp.is_whitespace, sp.is_type("dedent"))],
         )
 
         if len(trailing_newlines) == 1:


### PR DESCRIPTION
Previously updated anchor point of L009 to be end of the file. Needed to update the tests accordingly.

Also had changed the loop_while to continue on meta segments, intending indents/dedents, but forgot that includes template segments so reverted to continuing on dedents.